### PR TITLE
Include pgsql and redis packages for PHP7.

### DIFF
--- a/pimpMyBox/php7.md
+++ b/pimpMyBox/php7.md
@@ -16,6 +16,8 @@
         && php7.0 \
         && php7.0-fpm \
         && php7.0-mysql \
+        && php7.0-pgsql \
+        && php-redis \
         && php-curl \
         && libapache2-mod-php7.0 \
         && php7.0-mbstring


### PR DESCRIPTION
I saw your guide for upgrade Scotch Box to PHP7 linked a few times around the net, and I would recommend making this change to it.

Without the `php7.0-pgsql` and `php-redis` packages, the default landing page included in Scotch Box will not work. Which means you are deviating from the standard quite a bit. Including these two extra packages make sure the landing page will render without PHP errors and display green check marks on almost everything.

The only check mark still missing after this is “Memcached running”, which requires `php-memcached` and/or `php-memcache`.
